### PR TITLE
Sf details registration

### DIFF
--- a/src/ApplicationViews.js
+++ b/src/ApplicationViews.js
@@ -11,6 +11,7 @@ import Registration from "./components/auth/Registration"
 import Home from "./components/home/Home";
 
 //medication
+import MedicationCard from "./components/medication/MedicationCard";
 import AddMedicationFormModal from "./components/medication/AddMedicationFormModal";
 import MedicationList from "./components/medication/MedicationList";
 import MedicationHistoryList from "./components/history/MedicationHistoryList";
@@ -57,6 +58,12 @@ const ApplicationViews = (props) => {
         return (hasUser ? <MedicationHistoryList {...props} /> : <Redirect to="/login" />)
     }}
     />
+
+    {/* <Route path="/medication/search"
+    render={props => {
+        return (hasUser ? <MedicationCard {...props} /> : <Redirect to="/login" />)
+    }}
+    /> */}
 </>
  )   
  

--- a/src/ApplicationViews.js
+++ b/src/ApplicationViews.js
@@ -11,7 +11,7 @@ import Registration from "./components/auth/Registration"
 import Home from "./components/home/Home";
 
 //medication
-import MedicationCard from "./components/medication/MedicationCard";
+import MedicationDetail from "./components/medication/MedicationDetail";
 import AddMedicationFormModal from "./components/medication/AddMedicationFormModal";
 import MedicationList from "./components/medication/MedicationList";
 import MedicationHistoryList from "./components/history/MedicationHistoryList";
@@ -56,6 +56,12 @@ const ApplicationViews = (props) => {
     <Route path="/medication/history"
     render={props => {
         return (hasUser ? <MedicationHistoryList {...props} /> : <Redirect to="/login" />)
+    }}
+    />
+
+    <Route exact path="/medication/detail/:drugId(\d+)"
+    render={props => {
+        return (hasUser ? <MedicationDetail {...props} drugId={parseInt(props.match.params.drugId)} /> : <Redirect to="/login" />)
     }}
     />
 

--- a/src/components/auth/Login.js
+++ b/src/components/auth/Login.js
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { Button, Form, FormGroup, Jumbotron, Container, Modal, ModalHeader, ModalBody, ModalFooter } from "reactstrap";
 import ApplicationManager from "../modules/ApplicationManager";
 
+
 const Login = (props) => {
     const setUser = props.setUser;
     const [modal, setModal] = useState(false);
@@ -88,9 +89,8 @@ const Login = (props) => {
                     </ModalBody>
                     <ModalFooter>
                         <Button color="primary" onClick={toggle}>
-                            Try again
+                           {'Try again'}
                         </Button>
-                        {' '}
                     </ModalFooter>
                 </Modal>
                 </div>

--- a/src/components/auth/Registration.js
+++ b/src/components/auth/Registration.js
@@ -1,14 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import { Button, Form, FormGroup, Jumbotron, Container } from "reactstrap";
 import ApplicationManager from "../modules/ApplicationManager";
 
 
 const Registration = (props) => {
-    let findUsername;
     const setUser = props.setUser;
-
-    const [newUser, setNewUser] = useState({id:"", username: "", email: "", password: "", image: "" })
+    const [newUser, setNewUser] = useState({username: "", email: "", password: "", image: "" })
+    const [allUsers, setAllUsers] = useState([])
     const [isLoading, setIsLoading] = useState(false);
 
     const handleFieldChange = event => {
@@ -17,18 +16,32 @@ const Registration = (props) => {
         setNewUser(stateToChange);
     };
 
+    const getUsers = () => {
+        ApplicationManager.getUsers().then(usersFromAPI => {
+            setAllUsers(usersFromAPI)
+        })
+    }
+    
+    useEffect(() => {
+        getUsers()
+    },[]);
+    
     const registerNewUser = event => {
         event.preventDefault();
         let confirmPassword = document.querySelector("#confirmPassword").value;
-
-        ApplicationManager.getUsers()
-            .then(usersFromAPI => {
-            findUsername = usersFromAPI.find(userObj => {
+            let findUserEmail = allUsers.find(userObj => {
+                return userObj.email === newUser.email 
+             })
+            let findUsername = allUsers.find(userObj => {
                return userObj.username === newUser.username  
             })
-            if (findUsername) {
-                alert("Username already exists");
+            if (findUsername && findUserEmail ) {
+                alert("User email and username already exist")
                 document.getElementById("registerForm").reset()
+            } else if (findUserEmail) {
+                alert("User email already exists")
+            } else if (findUsername) {
+                alert("Username already exists");
             } else if (newUser.username === "" || newUser.email === "" || newUser.password === "") {
                 alert("Please fill out each field")
             } else if (newUser.password !== confirmPassword) {
@@ -36,34 +49,25 @@ const Registration = (props) => {
             } else {
                 // user.image = 
                 setIsLoading(true)
-                sessionStorage.setItem("user", JSON.stringify(newUser))
-                setUser(newUser)
                 ApplicationManager.postNewUser(newUser).then(() => {
-                    alert("Success! New Account Created! Please login.")
-                    props.history.push("/login")
+                    ApplicationManager.getUsers().then(result => {
+                        result.find(user => {
+                            if (user.username === newUser.username) {
+                                newUser.id = user.id
+                                setUser(newUser)
+                                props.history.push("/")
+                            }
+                        })
+                        
+                    })
                     
                 })
                
             }
-    
-        })
         
     }  
 
-    
-
-    // ApplicationManager.postNewUser(newUser).then(() => 
-    // ApplicationManager.getUsers(usersFromAPI => {
-    //     usersFromAPI.find(userFromAPI => {
-    //        if(newUser.username === userFromAPI.username) {
-    //             console.log(newUser)
-    //             sessionUser = sessionStorage.setItem("user", JSON.stringify(newUser))
-    // setUser(newUser)
-    
-    //        }
-    //     })
-    // }) 
-    // )
+ 
 
    return (
         <>

--- a/src/components/auth/Registration.js
+++ b/src/components/auth/Registration.js
@@ -6,7 +6,6 @@ import ApplicationManager from "../modules/ApplicationManager";
 
 const Registration = (props) => {
     let findUsername;
-    let sessionUser;
     const setUser = props.setUser;
 
     const [newUser, setNewUser] = useState({id:"", username: "", email: "", password: "", image: "" })

--- a/src/components/history/MedicationHistoryCard.js
+++ b/src/components/history/MedicationHistoryCard.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import {
     Card, Button, CardImg, CardTitle, CardText, CardDeck,
     CardSubtitle, CardBody, UncontrolledCollapse, CustomInput
@@ -7,7 +8,7 @@ import {
 const MedicationHistoryCard = (props) => {
   const sessionUser = JSON.parse(sessionStorage.getItem("user"))
 
-  const currentDrugTaking = {
+  const currentDrugNotTaking = {
     id: props.drug.id,
     name: props.drug.name,
     userId: sessionUser.id,
@@ -32,9 +33,9 @@ const MedicationHistoryCard = (props) => {
       <Card body color="warning"  >
         <strong>Date Entered:</strong> {props.drug.dateInput}
         <span>
-        <input id="checkbox" type="checkbox" className="checkbox" checked={props.isChecked} value={props.drug.taking} onClick={() => props.handleChange(currentDrugTaking)}
+        <input id="checkbox" type="checkbox" className="checkbox" checked={props.isChecked} value={props.drug.taking} onClick={() => props.handleChange(currentDrugNotTaking)}
         /> 
-         <label for="checkbox">Save to Medication History</label>
+         <label htmlFor="checkbox">Save to Medication History</label>
          </span>
         {/* <Button  onClick={() => props.history.push("/medication/history")} >Save to Medication History</Button> */}
       
@@ -63,7 +64,9 @@ const MedicationHistoryCard = (props) => {
         
         </CardBody>
           <Button>Edit</Button>
+          <Link to={`/medication/detail/${props.drug.id}`}>
           <Button>Details</Button>
+          </Link>
           <Button onClick={() => props.removeDrug(props.drug.id)}>Delete</Button>
       </Card>
       <Button color="primary" id="toggler" style={{ marginBottom: '1rem' }}>

--- a/src/components/history/MedicationHistoryList.js
+++ b/src/components/history/MedicationHistoryList.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import MedicationHistoryCard from "./MedicationHistoryCard";
-import MedicationCard from "../medication/MedicationCard";
 import ApplicationManager from "../modules/ApplicationManager";
 import NavBar from "../nav/NavBar";
 
@@ -59,7 +58,7 @@ const MedicationHistoryList = (props) => {
                     drug={drug}
                     handleChange={handleChange}
                     isLoading={isLoading}
-                    ischecked={isChecked}
+                    isChecked={isChecked}
                     removeDrug={removeDrug}
                     {...props} 
                     />  

--- a/src/components/medication/AddMedicationFormModal.js
+++ b/src/components/medication/AddMedicationFormModal.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Form, FormGroup, Button, Modal, ModalHeader, ModalBody, ModalFooter} from "reactstrap";
 
 
-const AddMedicationFormModal = ({isLoading, handleFieldChange, handleAddNewDrug, newDrug, toggle, modal, toggleNested, toggleAll, nestedModal, closeAll, ...props}) => {
+const AddMedicationFormModal = ({isLoading, handleFieldChange, handleAddNewDrug, newDrug, toggle, modal, toggleNested, toggleAll, nestedModal, closeAll}) => {
     
     return (
         <>
@@ -77,7 +77,7 @@ const AddMedicationFormModal = ({isLoading, handleFieldChange, handleAddNewDrug,
                 </Form>
                 <Button color="success" onClick={toggleNested}>Refill Details</Button>
                 <Modal isOpen={nestedModal} toggle={toggleNested} onClosed={closeAll ? toggle : undefined}>
-            <ModalHeader>Prescription Details</ModalHeader>
+            <ModalHeader>Prescription Details (leave blank if over the counter)</ModalHeader>
             <ModalBody>
             {/* start of nested form */}
             <Form className="form-group d-lg-inline-flex flex-column bd-highlight">
@@ -123,7 +123,7 @@ const AddMedicationFormModal = ({isLoading, handleFieldChange, handleAddNewDrug,
           </Modal>
                 </ModalBody>
                             <ModalFooter>
-                                <Button color="primary" isLoading={false}onClick={handleAddNewDrug}>
+                                <Button color="primary" isLoading={isLoading} onClick={handleAddNewDrug}>
                                     {'Add Medication'}
                                 </Button>
                                 

--- a/src/components/medication/MedicationCard.js
+++ b/src/components/medication/MedicationCard.js
@@ -1,4 +1,5 @@
 import React from "react";
+import {Link} from "react-router-dom";
 import {
     Card, Button, CardImg, CardTitle, CardText, CardDeck,
     CardSubtitle, CardBody, UncontrolledCollapse, CustomInput
@@ -51,11 +52,11 @@ const MedicationCard = (props) => {
           
           <CardText>
           <ul className="list-group list-group flex">
-          <li className="list-group-item"><strong>How I Should Take My Medication:</strong>{props.drug.directions}</li>
+          <li className="list-group-item"><strong>How I Should Take My Medication:</strong> {props.drug.directions}</li>
           <li className="list-group-item"><strong>Why am I taking this?:</strong> {props.drug.indication}</li>
           
           {props.drug.notes === "" ? null : 
-          <li className="list-group-item"><strong>Notes for me:</strong>: {props.drug.notes}</li>     
+          <li className="list-group-item"><strong>Notes for me:</strong> {props.drug.notes}</li>     
           }
           </ul>
           </CardText>
@@ -63,9 +64,14 @@ const MedicationCard = (props) => {
         
         </CardBody>
           <Button>Edit</Button>
+          <Link to={`/medication/detail/${props.drug.id}`}>
           <Button>Details</Button>
+          </Link>
           <Button onClick={() => props.removeDrug(props.drug.id)}>Delete</Button>
+      
       </Card>
+      {props.drug.rxNumber === "" && props.drug.dateFilled === "" && props.drug.daysSupply === "" ? null : 
+      <>
       <Button color="primary" id="toggler" style={{ marginBottom: '1rem' }}>
       Rx Details
       </Button>
@@ -78,9 +84,9 @@ const MedicationCard = (props) => {
           <CardText>
           <ul className="list-group list-group">
           <li className="list-group-item"><strong>RxNumber:</strong> {props.drug.rxNumber}</li>
-          <li className="list-group-item"><strong>Last time this was filled:</strong>: {props.drug.dateFilled}</li>     
-          <li className="list-group-item"><strong>How long is this going to last me?:</strong> {props.drug.daysSupply} days</li>     
-          <li className="list-group-item"><strong>When should I fill this next?:</strong>: {props.drug.nextRefillDate}</li>     
+          <li className="list-group-item"><strong>Last time this was filled:</strong> {props.drug.dateFilled}</li>     
+          <li className="list-group-item"><strong>How long is this going to last me?</strong> {props.drug.daysSupply} days</li>     
+          <li className="list-group-item"><strong>When should I fill this next?</strong> {props.drug.nextRefillDate}</li>     
           </ul> 
           </CardText>
         </CardBody>
@@ -89,6 +95,8 @@ const MedicationCard = (props) => {
           <Button>Delete</Button>
       </Card>
       </UncontrolledCollapse>
+      </>
+      }
     </CardDeck> 
   }
     </>

--- a/src/components/medication/MedicationDetail.js
+++ b/src/components/medication/MedicationDetail.js
@@ -1,0 +1,140 @@
+import React, { useState, useEffect } from "react";
+import NavBar from "../nav/NavBar";
+import ApplicationManager from "../modules/ApplicationManager";
+import {
+    Card, Button, CardImg, CardTitle, CardText, CardDeck,
+    CardSubtitle, CardBody, UncontrolledCollapse, CustomInput
+  } from 'reactstrap';
+
+const MedicationDetail = (props) => {
+    const [drug, setDrug] = useState({
+            id: "",
+            name: "",
+            userId: "", 
+            strength: "",
+            dosageForm: "", 
+            directions: "",
+            indication: "",
+            notes: "",
+            rxNumber: "", 
+            dateFilled: "", 
+            daysSupply: "", 
+            nextRefillDate: "", 
+            dateInput: "",
+            taking: true
+        
+    })
+
+    const [isLoading, setIsLoading] = useState(true)
+    const [isChecked, setIsChecked] = useState(false)
+    
+
+    useEffect( () => {
+        ApplicationManager.getDrugById(props.drugId)
+            .then(drug => {
+                setDrug({
+                    ...drug
+                });
+                setIsLoading(false)
+            })
+    }, [props.drugId])
+
+    const removeDrug = () => {
+        setIsLoading(true);
+        ApplicationManager.deleteDrug(props.drugId).then(() => {
+            props.history.push("/medication/list")
+        })
+    }
+
+    //edit the property "taking" to false and move card to medication hx  
+    const handleChange = (drugToEdit) => {
+        setIsChecked(true)
+        setIsLoading(true)
+        ApplicationManager.editDrug(drugToEdit)
+        .then(() => {
+            ApplicationManager.getUserDrugById(drug.id).then((drugFromAPI) => {
+                setDrug(drugFromAPI)
+                props.history.push("/medication/history")
+        
+            })
+            
+        })
+     }
+
+     //object to be sent to handelChange function that will edit property of "taking" to false and move card to medication hx
+     const currentDrugDetail = {
+         ...drug,
+         taking: false
+     }
+
+    return (
+        <>
+    <div>
+    <NavBar {...props} />
+    </div>
+    <CardDeck>
+      <Card body color="success" >
+        <strong>Date Entered:</strong> {drug.dateInput}
+        <span>
+          <input id="checkbox" type="checkbox" className="checkbox" checked={isChecked} value={drug.taking} onClick={() => handleChange(currentDrugDetail)}
+          /> 
+          <label for="checkbox">Save to Medication History</label>
+         </span>
+        {/* <Button  onClick={() => props.history.push("/medication/history")} >Save to Medication History</Button> */}
+      
+        {/* <CardImg className="img-thumbnail"src={"https://img.icons8.com/dusk/64/000000/prescription-pill-bottle.png/"} alt="medicationBottle" /> */}
+        <CardBody>
+          <CardTitle>
+          <ul className="list-group list-group flex">
+          <li className="list-group-item"><strong>Medication Name:</strong> {drug.name}</li>
+          <li className="list-group-item"><strong>Medication Strength:</strong> {drug.strength}</li>
+          <li className="list-group-item"><strong>Medication Type:</strong> {drug.dosageForm}</li>
+          </ul>
+          </CardTitle>
+          {/* <CardSubtitle></CardSubtitle> */}
+          
+          <CardText>
+          <ul className="list-group list-group flex">
+          <li className="list-group-item"><strong>How I Should Take My Medication:</strong>{drug.directions}</li>
+          <li className="list-group-item"><strong>Why am I taking this?:</strong> {drug.indication}</li>
+          
+          {drug.notes === "" ? null : 
+          <li className="list-group-item"><strong>Notes for me:</strong>: {drug.notes}</li>     
+          }
+          </ul>
+          </CardText>
+          <hr/>
+        
+        </CardBody>
+          <Button>Edit</Button>
+          <Button onClick={() => removeDrug(drug.id)}>Delete</Button>
+      </Card>
+      <Button color="primary" id="toggler" style={{ marginBottom: '1rem' }}>
+      Rx Details
+      </Button>
+      <UncontrolledCollapse toggler="#toggler">
+      <Card>
+        {/* <CardImg top width="100%" src="png" alt="bottle" /> */}
+        <CardBody> 
+          <CardTitle><strong>Prescription Details</strong></CardTitle>
+          {/* <CardSubtitle>Card subtitle</CardSubtitle> */}
+          <CardText>
+          <ul className="list-group list-group">
+          <li className="list-group-item"><strong>RxNumber:</strong> {drug.rxNumber}</li>
+          <li className="list-group-item"><strong>Last time this was filled:</strong>: {drug.dateFilled}</li>     
+          <li className="list-group-item"><strong>How long is this going to last me?:</strong> {drug.daysSupply} days</li>     
+          <li className="list-group-item"><strong>When should I fill this next?:</strong>: {drug.nextRefillDate}</li>     
+          </ul> 
+          </CardText>
+        </CardBody>
+          <Button>Edit</Button>
+          <Button>Delete</Button>
+      </Card>
+      </UncontrolledCollapse>
+    </CardDeck> 
+  
+    </>
+
+    )
+}
+export default MedicationDetail

--- a/src/components/medication/MedicationList.js
+++ b/src/components/medication/MedicationList.js
@@ -31,7 +31,7 @@ const MedicationList = (props) => {
         });
     };
 
-     //edit taking to false   
+     //edit taking to false and move card to medication hx  
     const handleChange = (drugToEdit) => {
         setIsChecked(true)
         setIsLoading(true)

--- a/src/components/medication/MedicationList.js
+++ b/src/components/medication/MedicationList.js
@@ -49,7 +49,7 @@ const MedicationList = (props) => {
 
     return (
         <>
-        <NavBar {...props} />
+        <NavBar {...props} drugs={drugs} />
         <section className="">
         <div className="">
             <h3>Current Medication List</h3>

--- a/src/components/modules/ApplicationManager.js
+++ b/src/components/modules/ApplicationManager.js
@@ -2,10 +2,13 @@ const remoteURL = "http://localhost:5002"
 
 export default {
     //user calls
+
+    //get all users from database
     getUsers() {
        return fetch(`${remoteURL}/users`).then(result => result.json())
     },
 
+    //adding new user upon registration 
     postNewUser(newUserObject) {
         return fetch(`${remoteURL}/users`, {
             method: "POST",
@@ -17,6 +20,8 @@ export default {
   },
 
   //medication calls
+  
+  //get user specific list of drugs based of session storage userId
   getDrugsForUser(sessionUserId) {
     return fetch(`${remoteURL}/drugs/?userId=${sessionUserId}&_expand=user`).then(data => data.json())
   },
@@ -25,18 +30,22 @@ export default {
     return fetch(`${remoteURL}/users/${id}?_embed=drugs`).then(data => data.json())
   },
 
+  //get all the drugs in list regardless of user
   getAllDrugs() {
     return fetch(`${remoteURL}/drugs`).then(data => data.json())
   },
 
+  //get drug by drugId
   getDrugById(id) {
     return fetch(`${remoteURL}/drugs/${id}`).then(data => data.json())
   },
 
-  getSearchKeyword(searchTerm) {
-    return fetch(`${remoteURL}/drugs?q=${searchTerm}`).then(data => data.json())
+  //get drug by drugId specific to userId that takes the drug
+  getUserDrugById(drugId) {
+    return fetch(`${remoteURL}/drugs/${drugId}/?_expand=user`).then(data => data.json())
   },
 
+  //posting new drug
   postNewDrug(newDrugObject) {
     return fetch(`${remoteURL}/drugs`, {
       method: "POST",
@@ -48,6 +57,7 @@ export default {
       
   },
 
+  //editing drug
   editDrug(drugObject) {
     return fetch(`${remoteURL}/drugs/${drugObject.id}`, {
       method: "PUT",
@@ -60,6 +70,7 @@ export default {
   },
 
 
+  //deleting drug
   deleteDrug(id) {
     return fetch(`${remoteURL}/drugs/${id}`, {
         method: "DELETE"

--- a/src/components/modules/ApplicationManager.js
+++ b/src/components/modules/ApplicationManager.js
@@ -33,6 +33,10 @@ export default {
     return fetch(`${remoteURL}/drugs/${id}`).then(data => data.json())
   },
 
+  getSearchKeyword(searchTerm) {
+    return fetch(`${remoteURL}/drugs?q=${searchTerm}`).then(data => data.json())
+  },
+
   postNewDrug(newDrugObject) {
     return fetch(`${remoteURL}/drugs`, {
       method: "POST",

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -35,6 +35,7 @@ const NavBar = (props, drugs) => {
                   <NavItem>
                     <NavLink className="nav-link" onClick={props.clearUser} href="/login">Logout</NavLink>
                   </NavItem> 
+                  {/* will only be showing nav bar if user is logged in --don't need Login? (directs back to homepage) */}
                   {/* <NavItem>
                     <NavLink className="nav-link" href="/login">Login</NavLink>
                   </NavItem> */}

--- a/src/components/nav/NavBar.js
+++ b/src/components/nav/NavBar.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import SearchBar from "../search/SearchBar";
 import { Collapse, Navbar, NavbarToggler, NavbarBrand, Nav, NavItem, NavLink } from 'reactstrap';
 
-const NavBar = (props) => {
+const NavBar = (props, drugs) => {
     const hasUser = props.hasUser
    
     const [collapsed, setCollapsed] = useState(true);
@@ -40,7 +40,7 @@ const NavBar = (props) => {
                   </NavItem> */}
                 </Nav>
                  <span>
-                   <SearchBar {...props}/>
+                   <SearchBar {...props} drugs={drugs}/>
                  </span>
               </Collapse>
             </Navbar>

--- a/src/components/search/SearchBar.js
+++ b/src/components/search/SearchBar.js
@@ -1,16 +1,78 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
+import MedicationCard from "../medication/MedicationCard";
+import ApplicationManager from "../modules/ApplicationManager";
 
-const SearchBar = () => {
-    const [searchTerm, setSearchTerm ] = useState({
-        //what do I want to search?
-    })
 
-    return (
-        <form class="form-inline my-2 my-lg-0">
-            <input class="form-control mr-sm-2" type="search" placeholder="Search for keywords" aria-label="Search"/>
-            <button class="btn btn-outline-primary my-2 my-sm-0" type="submit">Search</button>
-        </form>
-    )
+const SearchBar = (props ) => {
+    let searchResult;
+    const sessionUser = JSON.parse(sessionStorage.getItem("user"))
+//put searchTerm into state
+const [searchTerm, setSearchTerm ] = useState({
+    keywordSearch: ""
+})
+const [drugsArray, setDrugsArray] = useState([])
+
+const handleFieldChange = (event) => {
+    const stateToChange = {...searchTerm}
+    stateToChange[event.target.id] = event.target.value
+    setSearchTerm(stateToChange)
+    console.log(event.target.value)
 }
 
+const getMatchingCards = () => {
+    
+   ApplicationManager.getDrugsForUser(sessionUser.id)
+        .then(drugsFromAPI => {
+           
+            setDrugsArray(drugsFromAPI)
+            console.log(drugsFromAPI)
+        }).then(
+            searchResult= drugsArray.filter(drug => {
+            console.log(drug)
+            let drugValues = Object.values(drug)
+            console.log(drugValues)
+
+            return setDrugsArray(drug.name
+                .toLowerCase()
+                .includes(searchTerm.keywordSearch.toLowerCase()))
+                
+        }).map((drug) => {
+            return <div>{drug}</div>
+        })
+    )
+}
+           
+            
+
+useEffect(() => {
+    getMatchingCards();
+},[])
+
+ //what do I want to search?: 
+    //how do I get this info? do getall drugs by userId
+    //what do you do next? iterate through fetch and get all values of each object
+    //set search term to state 
+    //if search term matches object value...
+    //get medication card data
+    //show it in new page with search criteria 
+
+   
+    return (
+        <>
+        <form onSubmit={getMatchingCards} class="form-inline my-2 my-lg-0">
+            <input class="form-control mr-sm-2" name="keywordSearch" id="keywordSearch" onChange={handleFieldChange} 
+            type="text" placeholder="Search for keywords" value={searchTerm.keywordSearch}
+            aria-label="Search"/>
+            <button class="btn btn-outline-primary my-2 my-sm-0" type="submit" >Search</button>
+        </form>
+
+        <div>
+       
+        
+           
+        </div>
+        </>
+    )
+}
+ 
 export default SearchBar

--- a/src/components/search/SearchResult.js
+++ b/src/components/search/SearchResult.js
@@ -1,0 +1,17 @@
+// import React, { useState, useEffect } from "react";
+// import SearchBar from "../search/SearchBar";
+// import MedicationCard from "../medication/MedicationCard";
+// import ApplicationManager from "../modules/ApplicationManager";
+
+// const SearchResults = (props) => {
+    
+//     return (
+//         <>
+//         <SearchBar handleFieldChange={handleFieldChange}
+//         getMatchingCards={getMatchingCards}
+//         {...props} />
+//         <MedicationCard {...props} />
+//         </>
+//     )
+// }
+// export default SearchResults;


### PR DESCRIPTION
# Description
Fixes #3 and #5 
1. Realized when new user registers their id does not get stored into session storage (only username, email, and password)
2. Fixed registration issue where now user can register new account and their id will be stored into session storage along with other log-in information
3. From medication list will be able to click details button and see details of individual drug entry
4. Can send the medication details card to med history and from med history can send card back to current medication list 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Testing Instructions
1. pull down  sf-details-registration
2. npm start in terminal
3. json-server -p 5002 -w database.json
4. from login page, click register and fill out form; upon registration, should open applications in dev tools to see session storage now stores id of user as well as other login information
5. from medication list should be able to click details button and be brought to details of individual drug
6. should be able to click save to history checkbox and card should be brought to medication history list 
7. should be able to click checkbox on card in medication history list and card should be brought back to current medication list 

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works